### PR TITLE
Remove useless deps in terminus

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -15,12 +15,9 @@
   (synopsis "A generic client to interact with Rest API")
   (description "Terminus provides the basic functionalities for a Rest API requester.")
   (depends
-    (ocaml (and (>= 4.08.0) (< 5.0.0)))
+    (ocaml (>= 4.08.0))
     (ezjsonm (>= 1.3.0))
-    (lwt (>= 5.3.0))
     (odate (>= 0.6))
-    (alcotest :with-test)
-    (alcotest-lwt :with-test)
     ppx_deriving
     (odoc :with-doc))
   (conflicts
@@ -33,10 +30,10 @@
     "Terminus-hlc is an implementation of the Terminus specifications using http-lwt-client.")
   (depends
     (terminus (= :version))
+    (ocaml (and (>= 4.08.0) (< 5.0.0)))
     http-lwt-client
     (httpaf-lwt-unix :with-test)
     (alcotest :with-test)
-    (alcotest-lwt :with-test)
     (odoc :with-doc))
   (conflicts
     (result (< 1.5))))
@@ -48,11 +45,10 @@
     "Terminus-cohttp is an implementation of the Terminus specification using cohttp-lwt-unix.")
   (depends
     (terminus (= :version))
+    (ocaml (and (>= 4.08.0) (< 5.0.0)))
     cohttp-lwt-unix
     (httpaf-lwt-unix :with-test)
     (alcotest :with-test)
-    (alcotest-lwt :with-test)
     (odoc :with-doc))
   (conflicts
     (result (< 1.5))))
-

--- a/dune-project
+++ b/dune-project
@@ -31,7 +31,7 @@
   (depends
     (terminus (= :version))
     (ocaml (and (>= 4.08.0) (< 5.0.0)))
-    http-lwt-client
+    (http-lwt-client (<= 0.8.0))
     (httpaf-lwt-unix :with-test)
     (alcotest :with-test)
     (odoc :with-doc))

--- a/dune-project
+++ b/dune-project
@@ -31,7 +31,7 @@
   (depends
     (terminus (= :version))
     (ocaml (and (>= 4.08.0) (< 5.0.0)))
-    (http-lwt-client (<= 0.8.0))
+    (http-lwt-client (< 0.1.0))
     (httpaf-lwt-unix :with-test)
     (alcotest :with-test)
     (odoc :with-doc))

--- a/terminus-cohttp.opam
+++ b/terminus-cohttp.opam
@@ -12,10 +12,10 @@ bug-reports: "https://github.com/maiste/terminus/issues"
 depends: [
   "dune" {>= "3.0"}
   "terminus" {= version}
+  "ocaml" {>= "4.08.0" & < "5.0.0"}
   "cohttp-lwt-unix"
   "httpaf-lwt-unix" {with-test}
   "alcotest" {with-test}
-  "alcotest-lwt" {with-test}
   "odoc" {with-doc}
 ]
 conflicts: [

--- a/terminus-hlc.opam
+++ b/terminus-hlc.opam
@@ -13,7 +13,7 @@ depends: [
   "dune" {>= "3.0"}
   "terminus" {= version}
   "ocaml" {>= "4.08.0" & < "5.0.0"}
-  "http-lwt-client" {>= "0.2.2"}
+  "http-lwt-client" {< "0.1.0"}
   "httpaf-lwt-unix" {with-test}
   "alcotest" {with-test}
   "odoc" {with-doc}

--- a/terminus-hlc.opam
+++ b/terminus-hlc.opam
@@ -13,7 +13,7 @@ depends: [
   "dune" {>= "3.0"}
   "terminus" {= version}
   "ocaml" {>= "4.08.0" & < "5.0.0"}
-  "http-lwt-client"
+  "http-lwt-client" {>= "0.2.2"}
   "httpaf-lwt-unix" {with-test}
   "alcotest" {with-test}
   "odoc" {with-doc}

--- a/terminus-hlc.opam
+++ b/terminus-hlc.opam
@@ -12,10 +12,10 @@ bug-reports: "https://github.com/maiste/terminus/issues"
 depends: [
   "dune" {>= "3.0"}
   "terminus" {= version}
+  "ocaml" {>= "4.08.0" & < "5.0.0"}
   "http-lwt-client"
   "httpaf-lwt-unix" {with-test}
   "alcotest" {with-test}
-  "alcotest-lwt" {with-test}
   "odoc" {with-doc}
 ]
 conflicts: [

--- a/terminus.opam
+++ b/terminus.opam
@@ -11,12 +11,9 @@ doc: "maiste.github.io/terminus"
 bug-reports: "https://github.com/maiste/terminus/issues"
 depends: [
   "dune" {>= "3.0"}
-  "ocaml" {>= "4.08.0" & < "5.0.0"}
+  "ocaml" {>= "4.08.0"}
   "ezjsonm" {>= "1.3.0"}
-  "lwt" {>= "5.3.0"}
   "odate" {>= "0.6"}
-  "alcotest" {with-test}
-  "alcotest-lwt" {with-test}
   "ppx_deriving"
   "odoc" {with-doc}
 ]

--- a/tests/helpers/dune
+++ b/tests/helpers/dune
@@ -1,3 +1,3 @@
 (library
  (name helpers)
- (libraries alcotest alcotest-lwt ezjsonm httpaf httpaf-lwt-unix terminus))
+ (libraries alcotest ezjsonm httpaf httpaf-lwt-unix terminus))


### PR DESCRIPTION
This PR removes the alcotest dependencies and moves the constraints to `terminus_cohttp` and `terminus_hlc` to prepare the split in multiple backends repositories.